### PR TITLE
Move XML templates and context menus to correct web-module subprojects

### DIFF
--- a/web-module/src/main/webapp/docs/celements2web/CalTemplates/Event.xml
+++ b/web-module/src/main/webapp/docs/celements2web/CalTemplates/Event.xml
@@ -3,7 +3,7 @@
 <web>CalTemplates</web>
 <name>Event</name>
 <language></language>
-<defaultLanguage>en</defaultLanguage>
+<defaultLanguage></defaultLanguage>
 <translation>0</translation>
 <parent></parent>
 <creator>xwiki:XWiki.ebeutler</creator>

--- a/web-module/src/main/webapp/docs/celements2web/CelementsContextMenu/cel_cm_calendar_event.xml
+++ b/web-module/src/main/webapp/docs/celements2web/CelementsContextMenu/cel_cm_calendar_event.xml
@@ -3,7 +3,7 @@
 <web>CelementsContextMenu</web>
 <name>cel_cm_calendar_event</name>
 <language></language>
-<defaultLanguage>en</defaultLanguage>
+<defaultLanguage></defaultLanguage>
 <translation>0</translation>
 <parent></parent>
 <creator>xwiki:XWiki.ebeutler</creator>

--- a/web-module/src/main/webapp/docs/celements2web/PageTypes/Calendar.xml
+++ b/web-module/src/main/webapp/docs/celements2web/PageTypes/Calendar.xml
@@ -3,7 +3,7 @@
 <web>PageTypes</web>
 <name>Calendar</name>
 <language></language>
-<defaultLanguage>en</defaultLanguage>
+<defaultLanguage></defaultLanguage>
 <translation>0</translation>
 <parent></parent>
 <creator>xwiki:XWiki.ebeutler</creator>

--- a/web-module/src/main/webapp/docs/celements2web/PageTypes/Event.xml
+++ b/web-module/src/main/webapp/docs/celements2web/PageTypes/Event.xml
@@ -3,7 +3,7 @@
 <web>PageTypes</web>
 <name>Event</name>
 <language></language>
-<defaultLanguage>en</defaultLanguage>
+<defaultLanguage></defaultLanguage>
 <translation>0</translation>
 <parent></parent>
 <creator>xwiki:XWiki.ebeutler</creator>


### PR DESCRIPTION
This change refactors the location of various XML templates, page types, and context menus. Files that were previously added or modified in the main `celements-web` repository but logically belong to other component repositories have been relocated to their correct web-module subprojects. 

Across all touched repositories, these changes have been committed and pushed under the branch:
`update-celements2web-7x-onDisk`
